### PR TITLE
Fixes issue #52 - Add executive leaders section to About Us

### DIFF
--- a/src/components/ExecutiveLeaders/allexecutives.jsx
+++ b/src/components/ExecutiveLeaders/allexecutives.jsx
@@ -1,0 +1,5 @@
+export const IMAGE_LINKS = [
+    "https://user-images.githubusercontent.com/42191425/195487234-8b413ac2-a707-4295-8488-5ee94fe52b04.png",
+    "https://user-images.githubusercontent.com/42191425/195487251-ad211be3-3f03-4486-9ccd-3d4b1bf6238a.png",
+    "https://user-images.githubusercontent.com/42191425/195487266-4d3e9ae3-4fcc-4503-b196-ef00b495ce4f.png"
+];

--- a/src/components/ExecutiveLeaders/index.jsx
+++ b/src/components/ExecutiveLeaders/index.jsx
@@ -1,0 +1,17 @@
+import CircularImg from "../CircularImg";
+import { IMAGE_LINKS } from "./allexecutives";
+
+export default function ExecutiveLeaders(){
+    return (<div class='grid place-items-center'>
+                <h1 class='flex flex-col text-center my-4'>Executive Leaders</h1>
+                <div class='grid grid-cols-1 gap-3 md:grid-cols-3 lg:grid-cols-3 m-2'>
+                {
+                    IMAGE_LINKS.map(
+                            (image)=>{
+                                return <CircularImg href={image}/>
+                            }
+                    )
+                }
+                </div>
+            </div>);
+}

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,9 +1,11 @@
 import './about.css'
 import SpeakersSection from '../components/SpeakersSection';
+import ExecutiveLeaders from '../components/ExecutiveLeaders';
 
 export default function About(){
     return (<div>
                 <h1>About</h1>
+                <ExecutiveLeaders/>
                 <SpeakersSection/>
             </div>
     );


### PR DESCRIPTION
Closes #52 

- Executive Speakers section added to About Us
- There is a centered "Executive Leaders" header 1 with proper styling
- There are 3 rounded pictures (see https://github.com/acm-uic/flourish-2023/issues/51) with proper spacing (~0.5rem to start, check the figma design as a guide)
- All pictures used are placeholder images attached to this issue
- Flows onto multiple lines and go down to a single line on mobile
- Dynamic and scalable, adding more executive images simply requires adding new image links to the array in 
   src\components\ExecutiveLeaders\allexecutives.jsx


