### PR TITLE
Desktop Layout of Social Media Bubbles

### DIFF
--- a/src/components/DesktopSMBubbles/index.jsx
+++ b/src/components/DesktopSMBubbles/index.jsx
@@ -1,0 +1,21 @@
+import { FacebookSMBubble, InstagramSMBubble, LinkedinSMBubble, TwitterSMBubble, YoutubeSMBubble } from "../SocialMediaBubbles";
+
+export default function DesktopSMBubbles() {
+    return( 
+        <div className="grid h-screen place-items-center w-screen">  
+            <div className="relative items-center justify-center inline-flex w-7/12" >
+                <div className="relative items-center justify-center inline-flex z-0">
+                    <InstagramSMBubble/>
+                        <div className="relative items-center justify-center inline-flex w-5/12 z-10">
+                            <LinkedinSMBubble/>
+                            <div className="relative items-center justify-center inline-flex w-3/12 z-20">
+                                <YoutubeSMBubble/>
+                            </div>
+                            <TwitterSMBubble/>
+                        </div>
+                    <FacebookSMBubble/>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/social.js
+++ b/src/pages/social.js
@@ -1,11 +1,13 @@
 import './social.css'
 import ArchiveCarousel from '../components/ArchiveCarousel';
+import DesktopSMBubbles from '../components/DesktopSMBubbles';
 
 
 export default function Social(){
     return (
         <div>
             <h1>Social</h1>
+            <DesktopSMBubbles/>
             <ArchiveCarousel/>
         </div>
     


### PR DESCRIPTION
Fixes #80 

- The five bubbles are lain out in a carousel fashion (middle in front with each to the left and right descending behind)
- The bubbles are in the order Instagram, LinkedIn, YouTube, Twitter, and Facebook
- The overlap are consistent with the figma design
- Added to social media page
Here's a screenshot of the layout
<img width="801" alt="image" src="https://user-images.githubusercontent.com/69230048/202834976-9b01d01a-114d-4f57-b1a7-d5f8d0d65cea.png">